### PR TITLE
Fix issue with watermeter requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ async def main():
     """Show example on getting P1 Monitor data."""
     async with P1Monitor(host="example_host") as client:
         smartmeter = await client.smartmeter()
+        watermeter = await client.watermeter()
         print(smartmeter)
+        print(watermeter)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ There is a lot of data that you can read via the API:
 - Power Produced phases L1/2/3
 
 ### WaterMeter
+> **_NOTE:_**  WaterMeter is only available when you run version 0.9.14 or higher.
+
 - Day Consumption (liters)
 - Total Consumption (m3)
 - Day Pulse count

--- a/p1monitor/p1monitor.py
+++ b/p1monitor/p1monitor.py
@@ -128,10 +128,18 @@ class P1Monitor:
 
         Raises:
             P1MonitorNoDataError: No data was received from the P1 Monitor API.
+            error: Any type of error from the client response error handling.
         """
-        data = await self._request(
-            "v2/watermeter/day", params={"json": "object", "limit": 1}
-        )
+        try:
+            data = await self._request(
+                "v2/watermeter/day", params={"json": "object", "limit": 1}
+            )
+        except aiohttp.ClientResponseError as error:
+            if error.status == 404:
+                raise P1MonitorNoDataError(
+                    "No watermeter is connected to P1 Monitor"
+                ) from error
+            raise error
         if data == []:
             raise P1MonitorNoDataError("No data received from P1 Monitor")
         return WaterMeter.from_dict(data)

--- a/tests/test_p1monitor.py
+++ b/tests/test_p1monitor.py
@@ -14,7 +14,7 @@ from . import load_fixtures
 
 
 @pytest.mark.asyncio
-async def test__json_request(aresponses: ResponsesMockServer) -> None:
+async def test_json_request(aresponses: ResponsesMockServer) -> None:
     """Test JSON response is handled correctly."""
     aresponses.add(
         "example.com",
@@ -118,7 +118,7 @@ async def test_http_error401(aresponses: ResponsesMockServer, status: int) -> No
 
 
 @pytest.mark.asyncio
-async def test_http_error400(aresponses: ResponsesMockServer) -> None:
+async def test_http_error404(aresponses: ResponsesMockServer) -> None:
     """Test HTTP 404 response handling."""
     aresponses.add(
         "example.com",


### PR DESCRIPTION
Old versions of P1 Monitor give a 404 when you make a request for the water meter data, newer versions give an empty list `[]`.