### PR TITLE
Add optional port

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from p1monitor import P1Monitor
 
 async def main():
     """Show example on getting P1 Monitor data."""
-    async with P1Monitor(host="example_host", port=80) as client:
+    async with P1Monitor(host="192.168.1.2", port=80) as client:
         smartmeter = await client.smartmeter()
         watermeter = await client.watermeter()
         settings = await client.settings()

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from p1monitor import P1Monitor
 
 async def main():
     """Show example on getting P1 Monitor data."""
-    async with P1Monitor(host="example_host") as client:
+    async with P1Monitor(host="example_host", port=80) as client:
         smartmeter = await client.smartmeter()
         watermeter = await client.watermeter()
         settings = await client.settings()
@@ -54,6 +54,17 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+More examples can be found in the [examples folder](./examples/).
+
+## Class: `P1Monitor`
+
+This is the main class that you will use to interact with the P1 Monitor.
+
+| Parameter | Required | Description                                  |
+| --------- | -------- | -------------------------------------------- |
+| `host`    | `True`   | The IP address of the P1 Monitor.            |
+| `port`    | `False`  | The port of the P1 Monitor. Default is `80`. |
 
 ## Data
 

--- a/src/p1monitor/p1monitor.py
+++ b/src/p1monitor/p1monitor.py
@@ -23,6 +23,7 @@ class P1Monitor:
     """Main class for handling connections with the P1 Monitor API."""
 
     host: str
+    port: int = 80
     request_timeout: float = 10.0
     session: ClientSession | None = None
 
@@ -55,7 +56,12 @@ class P1Monitor:
             P1MonitorError: Received an unexpected response from the P1 Monitor API.
 
         """
-        url = URL.build(scheme="http", host=self.host, path="/api/").join(URL(uri))
+        url = URL.build(
+            scheme="http",
+            host=self.host,
+            port=self.port,
+            path="/api/",
+        ).join(URL(uri))
 
         headers = {
             "User-Agent": f"PythonP1Monitor/{VERSION}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,6 @@ async def client() -> AsyncGenerator[P1Monitor, None]:
     """Return a P1Monitor client."""
     async with (
         ClientSession() as session,
-        P1Monitor(host="192.168.1.2", session=session) as p1monitor_client,
+        P1Monitor(host="192.168.1.2", port=80, session=session) as p1monitor_client,
     ):
         yield p1monitor_client

--- a/tests/test_p1monitor.py
+++ b/tests/test_p1monitor.py
@@ -34,6 +34,24 @@ async def test_json_request(
     await p1monitor_client.close()
 
 
+async def test_different_port(aresponses: ResponsesMockServer) -> None:
+    """Test different port is handled correctly."""
+    aresponses.add(
+        "192.168.1.2:84",
+        "/api/test",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text='{"status": "ok"}',
+        ),
+    )
+    async with ClientSession() as session:
+        p1monitor = P1Monitor("192.168.1.2", port=84, session=session)
+        await p1monitor._request("test")
+        await p1monitor.close()
+
+
 async def test_internal_session(aresponses: ResponsesMockServer) -> None:
     """Test JSON response is handled correctly."""
     aresponses.add(


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->
With this change you could also use a different port if you for example run P1Monitor as a docker container instead of directly on a raspberry pi.

related to: https://github.com/home-assistant/core/issues/127394

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Go over all the following points, and put an `x` in all the boxes that apply.
    If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have updated the documentation if needed.
- [X] I have updated the tests if needed.
